### PR TITLE
Debug decreasing likelihood and numerical underflow problem

### DIFF
--- a/assignment2/Makefile
+++ b/assignment2/Makefile
@@ -15,3 +15,8 @@ train:
 .PHONY: clean
 clean:
 	@rm -rf feature_set
+
+
+.PHONY: test_emissions
+test_emissions:
+	@pytest tests/test_emissions.py

--- a/assignment2/Makefile
+++ b/assignment2/Makefile
@@ -20,3 +20,11 @@ clean:
 .PHONY: test_emissions
 test_emissions:
 	@pytest tests/test_emissions.py
+
+.PHONY: debug
+debug:
+	@python debugging.py
+
+.PHONY: compare
+compare:
+	@python compare_training.py

--- a/assignment2/compare_training.py
+++ b/assignment2/compare_training.py
@@ -1,0 +1,103 @@
+from hmm import HMM
+from mfcc_extract import load_mfccs_by_word
+import numpy as np
+import pandas as pd
+
+def debug_training_iteration(hmm_model, features, iteration):
+    """Debug a single training iteration by examining intermediate values."""
+    print(f"\nDEBUG: Iteration {iteration}")
+    
+    total_log_likelihood = 0
+    all_gammas = []
+    all_xis = []
+    
+    # Process each sequence
+    for seq_idx, features_seq in enumerate(features):
+        # Get emission probabilities
+        log_B = hmm_model.compute_log_emission_matrix(features_seq)
+        print(f"\nSequence {seq_idx + 1}")
+        print(f"Log emission matrix range: [{np.min(log_B):.2f}, {np.max(log_B):.2f}]")
+        
+        # Forward-backward passes
+        alpha = hmm_model.forward(log_B, use_log=True)
+        beta = hmm_model.backward(log_B, use_log=True)
+        
+        # Check for numerical issues in alpha/beta
+        print(f"Alpha range: [{np.min(alpha[alpha > -np.inf]):.2f}, {np.max(alpha):.2f}]")
+        print(f"Beta range: [{np.min(beta[beta > -np.inf]):.2f}, {np.max(beta):.2f}]")
+        
+        # Calculate gamma and xi
+        gamma = hmm_model.compute_gamma(alpha, beta, use_log=True)
+        xi = hmm_model.compute_xi(alpha, beta, log_B, use_log=True)
+        
+        # Check gamma and xi
+        print(f"Gamma range: [{np.min(gamma):.6f}, {np.max(gamma):.6f}]")
+        print(f"Gamma sum per frame: [{np.min(np.sum(gamma, axis=0)):.6f}, {np.max(np.sum(gamma, axis=0)):.6f}]")
+        if np.any(xi > 0):
+            print(f"Xi range: [{np.min(xi[xi > 0]):.6f}, {np.max(xi):.6f}]")
+        
+        # Accumulate for parameter updates
+        all_gammas.append(gamma)
+        all_xis.append(xi)
+        
+        # Calculate sequence log-likelihood
+        seq_log_likelihood = np.logaddexp.reduce(alpha[:, -1])
+        total_log_likelihood += seq_log_likelihood
+        print(f"Sequence log-likelihood: {seq_log_likelihood:.2f}")
+    
+    return total_log_likelihood, all_gammas, all_xis
+
+def compare_training(word="heed", n_states=8, n_iter=15):
+    """Compare training progress with reference implementation."""
+    print(f"Training comparison for word '{word}'")
+    
+    # Load and prepare data
+    features = load_mfccs_by_word("feature_set", word)
+    
+    # Initialize your HMM
+    hmm_model = HMM(n_states, 13, features, model_name=word)
+    
+    # Track progress over iterations
+    log_likelihoods = []
+    
+    for iteration in range(n_iter):
+        # Debug current iteration
+        total_log_likelihood, gammas, xis = debug_training_iteration(hmm_model, features, iteration + 1)
+        log_likelihoods.append(total_log_likelihood)
+        
+        # Calculate improvement
+        if iteration > 0:
+            improvement = total_log_likelihood - log_likelihoods[-2]
+            print(f"\nIteration {iteration + 1:2d}  {total_log_likelihood:14.8f}   {improvement:14.8f}")
+        else:
+            print(f"\nIteration {iteration + 1:2d}  {total_log_likelihood:14.8f}   {'nan':>14}")
+        
+        # Update parameters
+        # Convert accumulated statistics to the format your update methods expect
+        aggregated_gamma = np.sum(np.concatenate([g for g in gammas], axis=1), axis=1, keepdims=True)
+        aggregated_xi = np.sum([np.sum(x, axis=0) for x in xis], axis=0)
+        
+        # Update parameters
+        hmm_model.update_A(aggregated_xi, aggregated_gamma)
+        hmm_model.update_B(features, gammas)
+        
+        # Check parameter ranges after updates
+        print("\nParameter ranges after update:")
+        print(f"A matrix (excluding entry/exit): [{np.min(hmm_model.A[1:-1, 1:-1]):.6f}, {np.max(hmm_model.A[1:-1, 1:-1]):.6f}]")
+        print(f"Means: [{np.min(hmm_model.B['mean']):.6f}, {np.max(hmm_model.B['mean']):.6f}]")
+        print(f"Covariances: [{np.min(hmm_model.B['covariance']):.6f}, {np.max(hmm_model.B['covariance']):.6f}]")
+    
+    # Print final comparison with reference
+    print("\nTraining Summary:")
+    print("Your implementation:")
+    print(f"Starting log-likelihood: {log_likelihoods[0]:.2f}")
+    print(f"Final log-likelihood: {log_likelihoods[-1]:.2f}")
+    print(f"Total improvement: {log_likelihoods[-1] - log_likelihoods[0]:.2f}")
+    
+    print("\nReference implementation:")
+    print("Starting log-likelihood: -96816.39")
+    print("Final log-likelihood: -60768.75")
+    print("Total improvement: 36047.64")
+
+if __name__ == "__main__":
+    compare_training()

--- a/assignment2/debugging.py
+++ b/assignment2/debugging.py
@@ -1,0 +1,87 @@
+from hmmlearn import hmm
+import numpy as np
+from mfcc_extract import load_mfccs_by_word
+
+def initialize_hmm_parameters(features_list, n_states=8):
+    """
+    Initialize HMM parameters using global statistics and proper transition probabilities
+    based on average sequence duration.
+    
+    Args:
+        features_list: List of MFCC feature matrices
+        n_states: Number of HMM states
+    """
+    # Prepare data
+    lengths = [f.shape[1] for f in features_list]
+    X = np.concatenate([f.T for f in features_list], axis=0)
+    
+    # Calculate global statistics for emissions
+    means = np.mean(X, axis=0)
+    covars = np.var(X, axis=0)
+    min_var = 1e-3  # Variance floor to prevent numerical issues
+    covars = np.maximum(covars, min_var)
+    
+    # Calculate average sequence duration
+    avg_duration = np.mean(lengths)
+    frames_per_state = avg_duration / n_states
+    
+    # Calculate transition probabilities using the formula from assignment
+    aii = np.exp(-1 / (frames_per_state - 1))  # Self-transition probability
+    aij = 1 - aii  # Forward transition probability
+    
+    print(f"Average frames per state: {frames_per_state:.2f}")
+    print(f"Calculated self-transition probability: {aii:.3f}")
+    print(f"Calculated forward transition probability: {aij:.3f}")
+    
+    # Initialize the model
+    model = hmm.GaussianHMM(
+        n_components=n_states,
+        covariance_type="diag",
+        n_iter=15,
+        init_params="",
+        params="stmc",
+        verbose=True
+    )
+    
+    # Set start probabilities (start in first state)
+    startprob = np.zeros(n_states)
+    startprob[0] = 1.0
+    model.startprob_ = startprob
+    
+    # Set transition matrix using calculated probabilities
+    transmat = np.zeros((n_states, n_states))
+    for i in range(n_states-1):
+        transmat[i, i] = aii
+        transmat[i, i+1] = aij
+    transmat[-1, -1] = 1.0
+    model.transmat_ = transmat
+    
+    # Set emission parameters using global statistics
+    model.means_ = np.tile(means, (n_states, 1))
+    model.covars_ = np.tile(covars, (n_states, 1))
+    
+    return model, X, lengths
+
+def train_word_hmm(word="heed", n_states=8):
+    """Train HMM for a single word with proper initialization"""
+    print(f"\nTraining HMM for word '{word}'...")
+    
+    # Load features
+    features = load_mfccs_by_word("feature_set", word)
+    
+    # Initialize model with proper parameters
+    model, X, lengths = initialize_hmm_parameters(features, n_states)
+    
+    # Train the model
+    try:
+        model.fit(X, lengths)
+        log_likelihood = model.score(X, lengths)
+        print(f"Training completed. Final log-likelihood: {log_likelihood:.2f}")
+        return model, log_likelihood
+    except Exception as e:
+        print(f"Error during training: {str(e)}")
+        return None, None
+
+
+if __name__ == "__main__":
+    model, score = train_word_hmm("heed")

--- a/assignment2/hmm.py
+++ b/assignment2/hmm.py
@@ -151,6 +151,7 @@ class HMM:
 
     def compute_log_emission_matrix(self, features: np.ndarray) -> np.ndarray:
         emission_matrix = self.compute_emission_matrix(features)
+        self.print_matrix(emission_matrix, "Emission Matrix (B)", col="T", idx="State", start_idx=1, start_col=1)
         return np.log(emission_matrix)
 
     def forward(self, emission_matrix: np.ndarray, use_log=True) -> np.ndarray:

--- a/assignment2/hmm.py
+++ b/assignment2/hmm.py
@@ -4,6 +4,7 @@ import logging
 
 logging.basicConfig(level=logging.INFO)
 
+
 class HMM:
     def __init__(
         self,
@@ -149,10 +150,40 @@ class HMM:
             emission_matrix[j] = np.exp(exponent) / normalization
         return emission_matrix
 
+    # def compute_log_emission_matrix(self, features: np.ndarray) -> np.ndarray:
+    #     emission_matrix = self.compute_emission_matrix(features)
+    #     self.print_matrix(emission_matrix, "Emission Matrix (B)", col="T", idx="State", start_idx=1, start_col=1)
+    #     return np.log(emission_matrix)
+
     def compute_log_emission_matrix(self, features: np.ndarray) -> np.ndarray:
-        emission_matrix = self.compute_emission_matrix(features)
-        self.print_matrix(emission_matrix, "Emission Matrix (B)", col="T", idx="State", start_idx=1, start_col=1)
-        return np.log(emission_matrix)
+        """
+        For a multivariate Gaussian, the log probability is:
+        log(p(x)) = -0.5 * (d*log(2π) + log(|Σ|) + (x-μ)ᵀΣ⁻¹(x-μ))
+
+        Args:
+            features: Matrix of shape (num_features, T) containing MFCC features
+
+        Returns:
+            log_emission_matrix: Matrix of shape (num_states, T) containing log probabilities
+        """
+        T = features.shape[1]
+        log_emission_matrix = np.zeros((self.num_states, T))
+        const_term = -0.5 * self.num_obs * np.log(2 * np.pi)
+
+        for j in range(self.num_states):
+            # Compute log determinant term: -0.5 * log(|Σ|)
+            # For diagonal covariance, this is sum of logs
+            log_det = -0.5 * np.sum(np.log(self.B["covariance"][:, j]))
+
+            # Compute Mahalanobis distance term: -0.5 * (x-μ)ᵀΣ⁻¹(x-μ)
+            # For diagonal covariance, this simplifies to element-wise operations
+            diff = features - self.B["mean"][:, j : j + 1]
+            mahalanobis_squared = diff**2 / self.B["covariance"][:, j : j + 1]
+            mahalanobis_term = -0.5 * np.sum(mahalanobis_squared, axis=0)
+
+            # Combine all terms
+            log_emission_matrix[j] = const_term + log_det + mahalanobis_term
+        return log_emission_matrix
 
     def forward(self, emission_matrix: np.ndarray, use_log=True) -> np.ndarray:
         """
@@ -484,36 +515,37 @@ class HMM:
             f"Variance range: [{np.min(self.B['covariance']):.3f}, {np.max(self.B['covariance']):.3f}]"
         )
 
-
-    def baum_welch(self, features_list: list[np.ndarray], max_iter: int = 15, tol: float = 1e-4):
+    def baum_welch(
+        self, features_list: list[np.ndarray], max_iter: int = 15, tol: float = 1e-4
+    ):
         """
         Train the HMM using the Baum-Welch algorithm on multiple sequences.
         Returns the log likelihood values for each iteration to monitor convergence.
-        
+
         Args:
             features_list: List of observed feature matrices, each of shape (num_features, T).
             max_iter: Maximum number of iterations.
             tol: Convergence tolerance for log-likelihood improvement.
-        
+
         Returns:
             list[float]: Log likelihood values for each iteration
         """
         print(f"\nTraining `{self.model_name}` HMM using Baum-Welch algorithm...")
         prev_log_likelihood = float("-inf")
-        
+
         # Create list to store log likelihood for each iteration
         log_likelihood_history = []
 
         for iteration in range(max_iter):
             total_log_likelihood = 0
-            
+
             # Initialize accumulators for transition updates
             aggregated_gamma = np.zeros((self.num_states, 1))
             aggregated_xi = np.zeros((self.num_states, self.num_states))
-            
+
             # Store gamma values for each sequence
             gamma_per_seq = []
-            
+
             # E-Step across all sequences
             for seq_idx, features in enumerate(features_list):
                 # Compute forward-backward statistics
@@ -522,38 +554,40 @@ class HMM:
                 beta = self.backward(log_B, use_log=True)
                 gamma = self.compute_gamma(alpha, beta, use_log=True)
                 xi = self.compute_xi(alpha, beta, log_B, use_log=True)
-                
+
                 gamma_per_seq.append(gamma)
-                
+
                 # Accumulate statistics for transition updates
                 aggregated_gamma += np.sum(gamma, axis=1, keepdims=True)
                 aggregated_xi += np.sum(xi, axis=0)
-                
+
                 # Compute log-likelihood for this sequence
                 log_likelihood = np.logaddexp.reduce(alpha[:, -1])
                 total_log_likelihood += log_likelihood
-                
+
                 if len(features_list) > 10 and seq_idx % 10 == 0:
                     print(f"Processed sequence {seq_idx + 1}/{len(features_list)}...")
-            
+
             # Store the log likelihood for this iteration
             log_likelihood_history.append(total_log_likelihood)
-            
-            print(f"Iteration {iteration + 1}, Total Log-Likelihood: {total_log_likelihood}")
-            
+
+            print(
+                f"Iteration {iteration + 1}, Total Log-Likelihood: {total_log_likelihood}"
+            )
+
             # Check for convergence
             if abs(total_log_likelihood - prev_log_likelihood) < tol:
                 print(f"Converged after {iteration + 1} iterations!")
                 break
-                
+
             prev_log_likelihood = total_log_likelihood
-            
+
             # M-Step: Update model parameters
             self.update_A(aggregated_xi, aggregated_gamma)
             self.update_B(features_list, gamma_per_seq)
-        
+
         print("Baum-Welch training completed.")
-        
+
         # Print summary of likelihood changes
         total_improvement = log_likelihood_history[-1] - log_likelihood_history[0]
         print("\nTraining summary:")

--- a/assignment2/hmm.py
+++ b/assignment2/hmm.py
@@ -117,7 +117,6 @@ class HMM:
         print(df.round(precision))
 
     def print_emission_parameters(self, precision: int = 3) -> None:
-        # Print means
         print("\nMeans (each column is a state, each row is an MFCC coefficient):")
         means_df = pd.DataFrame(
             self.B["mean"],
@@ -126,7 +125,6 @@ class HMM:
         )
         print(means_df.round(precision))
 
-        # Print covariances
         print("\nVariances (each column is a state, each row is an MFCC coefficient):")
         cov_df = pd.DataFrame(
             self.B["covariance"],

--- a/assignment2/hmm.py
+++ b/assignment2/hmm.py
@@ -1,11 +1,8 @@
 import numpy as np
 import pandas as pd
-from mfcc_extract import load_mfccs
 import logging
-from matplotlib import pyplot as plt
 
 logging.basicConfig(level=logging.INFO)
-
 
 class HMM:
     def __init__(

--- a/assignment2/hmm.py
+++ b/assignment2/hmm.py
@@ -118,13 +118,10 @@ class HMM:
             normalization = np.sqrt((2 * np.pi) ** self.num_obs * determinant)
             emission_matrix[j] = np.exp(exponent) / normalization
         return emission_matrix
+    
 
-    # def compute_log_emission_matrix(self, features: np.ndarray) -> np.ndarray:
-    #     emission_matrix = self.compute_emission_matrix(features)
-    #     self.print_matrix(emission_matrix, "Emission Matrix (B)", col="T", idx="State", start_idx=1, start_col=1)
-    #     return np.log(emission_matrix)
 
-    def compute_log_emission_matrix(self, features: np.ndarray) -> np.ndarray:
+    def compute_emission_matrix(self, features: np.ndarray) -> np.ndarray:
         """
         For a multivariate Gaussian, the log probability is:
         log(p(x)) = -0.5 * (d*log(2π) + log(|Σ|) + (x-μ)ᵀΣ⁻¹(x-μ))
@@ -547,7 +544,7 @@ class HMM:
             # E-Step across all sequences
             for seq_idx, features in enumerate(features_list):
                 # Compute forward-backward statistics
-                log_B = self.compute_log_emission_matrix(features)
+                log_B = self.compute_emission_matrix(features)
                 alpha = self.forward(log_B, use_log=True)
                 beta = self.backward(log_B, use_log=True)
                 gamma = self.compute_gamma(alpha, beta, use_log=True)

--- a/assignment2/hmm.py
+++ b/assignment2/hmm.py
@@ -118,8 +118,6 @@ class HMM:
             normalization = np.sqrt((2 * np.pi) ** self.num_obs * determinant)
             emission_matrix[j] = np.exp(exponent) / normalization
         return emission_matrix
-    
-
 
     def compute_emission_matrix(self, features: np.ndarray) -> np.ndarray:
         """
@@ -158,177 +156,117 @@ class HMM:
 
         return log_emission_matrix
 
-    def forward(self, emission_matrix: np.ndarray, use_log=True) -> np.ndarray:
+    def forward(self, emission_matrix: np.ndarray) -> np.ndarray:
         """
         Compute forward probabilities α(t,j) including entry and exit states.
 
         Args:
             emission_matrix: Emission probabilities of shape (num_states, T)
                             Only includes real states (not entry/exit).
-            use_log: Whether to compute probabilities in log space.
         Returns:
             alpha: Forward probabilities of shape (num_states + 2, T)
                 Includes entry state (0) and exit state (num_states + 1).
         """
         T = emission_matrix.shape[1]  # Number of time steps
 
-        if use_log:
-            alpha = np.full((self.num_states + 2, T), -np.inf)
+        alpha = np.full((self.num_states + 2, T), -np.inf)
 
-            # Initialize t=0
-            alpha[0, 0] = -np.inf
-            alpha[1, 0] = np.log(self.A[0, 1]) + emission_matrix[0, 0]
+        # Initialize t=0
+        alpha[0, 0] = -np.inf
+        alpha[1, 0] = np.log(self.A[0, 1]) + emission_matrix[0, 0]
 
-            # Forward recursion
-            for t in range(1, T):
-                alpha[0, t] = -np.inf  # Entry state always -inf after t=0
+        # Forward recursion
+        for t in range(1, T):
+            alpha[0, t] = -np.inf  # Entry state always -inf after t=0
 
-                for j in range(1, self.num_states + 1):
-                    from_prev = alpha[j - 1, t - 1] + np.log(self.A[j - 1, j])
-                    self_loop = alpha[j, t - 1] + np.log(self.A[j, j])
-                    alpha[j, t] = (
-                        np.logaddexp(from_prev, self_loop) + emission_matrix[j - 1, t]
-                    )
+            for j in range(1, self.num_states + 1):
+                from_prev = alpha[j - 1, t - 1] + np.log(self.A[j - 1, j])
+                self_loop = alpha[j, t - 1] + np.log(self.A[j, j])
+                alpha[j, t] = (
+                    np.logaddexp(from_prev, self_loop) + emission_matrix[j - 1, t]
+                )
 
-                # Exit state (num_states + 1) - can only come from last real state
-                alpha[-1, t] = alpha[-2, t - 1] + np.log(self.A[-2, -1])
-
-        else:
-            alpha = np.zeros((self.num_states + 2, T))
-
-            # Initialize t=0
-            alpha[0, 0] = 0
-            alpha[1, 0] = self.A[0, 1] * emission_matrix[0, 0]
-
-            # Forward recursion
-            for t in range(1, T):
-                alpha[0, t] = 0  # Entry state always 0 after t=0
-
-                for j in range(1, self.num_states + 1):
-                    from_prev = alpha[j - 1, t - 1] * self.A[j - 1, j]
-                    self_loop = alpha[j, t - 1] * self.A[j, j]
-                    alpha[j, t] = (from_prev + self_loop) * emission_matrix[j - 1, t]
-
-                # Exit state (num_states + 1) - can only come from last real state
+            # Exit state (num_states + 1) - can only come from last real state
+            alpha[-1, t] = alpha[-2, t - 1] + np.log(self.A[-2, -1])
 
         return alpha
 
-    def backward(self, emission_matrix: np.ndarray, use_log=True) -> np.ndarray:
+    def backward(self, emission_matrix: np.ndarray) -> np.ndarray:
         """
         Compute backward probabilities β(t,j) including entry and exit states.
 
         Args:
             emission_matrix: Emission probabilities of shape (num_states, T)
                             Only includes real states (not entry/exit).
-            use_log: Whether to compute probabilities in log space.
         Returns:
             beta: Backward probabilities of shape (num_states + 2, T)
                 Includes entry state (0) and exit state (num_states + 1).
         """
         T = emission_matrix.shape[1]  # Number of time steps
 
-        if use_log:
-            beta = np.full((self.num_states + 2, T), -np.inf)
+        beta = np.full((self.num_states + 2, T), -np.inf)
 
-            # Initialize t=T-1
-            for j in range(self.num_states + 1):  # states 0 to 8
-                if self.A[j, -1] == 0:
-                    beta[j, T - 1] = -np.inf  # -inf if no transition to exit state
-                else:
-                    beta[j, T - 1] = np.log(self.A[j, -1])
-            beta[-1, T - 1] = -np.inf  # Exit state stays at -inf
+        # Initialize t=T-1
+        for j in range(self.num_states + 1):  # states 0 to 8
+            if self.A[j, -1] == 0:
+                beta[j, T - 1] = -np.inf  # -inf if no transition to exit state
+            else:
+                beta[j, T - 1] = np.log(self.A[j, -1])
+        beta[-1, T - 1] = -np.inf  # Exit state stays at -inf
 
-            # Backward recursion
-            for t in range(T - 2, -1, -1):  # Go from T-2 down to 0
-                beta[-1, t] = -np.inf  # Exit state stays at -inf
-                for j in range(self.num_states + 1):
-                    if j == self.num_states:  # State 8
-                        if self.A[j, j] == 0:
-                            beta[j, t] = -np.inf  # -inf if no self-loop
-                        else:
-                            beta[j, t] = (
-                                beta[j, t + 1]
-                                + np.log(self.A[j, j])
-                                + emission_matrix[j - 1, t + 1]
-                            )
+        # Backward recursion
+        for t in range(T - 2, -1, -1):  # Go from T-2 down to 0
+            beta[-1, t] = -np.inf  # Exit state stays at -inf
+            for j in range(self.num_states + 1):
+                if j == self.num_states:  # State 8
+                    if self.A[j, j] == 0:
+                        beta[j, t] = -np.inf  # -inf if no self-loop
                     else:
-                        if self.A[j, j] == 0:
-                            self_loop = -np.inf
-                        else:
-                            self_loop = (
-                                beta[j, t + 1]
-                                + np.log(self.A[j, j])
-                                + emission_matrix[j, t + 1]
-                            )
-                        if self.A[j, j + 1] == 0:
-                            to_next = -np.inf
-                        else:
-                            to_next = (
-                                beta[j + 1, t + 1]
-                                + np.log(self.A[j, j + 1])
-                                + emission_matrix[j, t + 1]
-                            )
-                        beta[j, t] = np.logaddexp(self_loop, to_next)
-
-        else:
-            beta = np.zeros((self.num_states + 2, T))
-
-            # Initialize t=T-1
-            for j in range(self.num_states + 1):  # states 0 to 8
-                beta[j, T - 1] = self.A[j, -1]
-            beta[-1, T - 1] = 0  # Exit state stays at 0
-
-            # Backward recursion
-            for t in range(T - 2, -1, -1):  # Go from T-2 down to 0
-                beta[-1, t] = 0  # Exit state stays at 0
-                for j in range(self.num_states + 1):
-                    if j == self.num_states:  # State 8
                         beta[j, t] = (
                             beta[j, t + 1]
-                            * self.A[j, j]
-                            * emission_matrix[j - 1, t + 1]
+                            + np.log(self.A[j, j])
+                            + emission_matrix[j - 1, t + 1]
                         )
+                else:
+                    if self.A[j, j] == 0:
+                        self_loop = -np.inf
                     else:
                         self_loop = (
-                            beta[j, t + 1] * self.A[j, j] * emission_matrix[j, t + 1]
+                            beta[j, t + 1]
+                            + np.log(self.A[j, j])
+                            + emission_matrix[j, t + 1]
                         )
+                    if self.A[j, j + 1] == 0:
+                        to_next = -np.inf
+                    else:
                         to_next = (
                             beta[j + 1, t + 1]
-                            * self.A[j, j + 1]
-                            * emission_matrix[j, t + 1]
+                            + np.log(self.A[j, j + 1])
+                            + emission_matrix[j, t + 1]
                         )
-                        beta[j, t] = self_loop + to_next
+                    beta[j, t] = np.logaddexp(self_loop, to_next)
 
         return beta
 
-    def compute_gamma(
-        self, alpha: np.ndarray, beta: np.ndarray, use_log=True
-    ) -> np.ndarray:
+    def compute_gamma(self, alpha: np.ndarray, beta: np.ndarray) -> np.ndarray:
         """
         Compute state occupation likelihood γ(t,j) for each state j and time t.
 
         Args:
             alpha: Forward probabilities of shape (num_states + 2, T)
             beta: Backward probabilities of shape (num_states + 2, T)
-            use_log: Whether probabilities are in log space
-
         Returns:
             gamma: State occupation likelihoods of shape (num_states, T)
                   Only includes real states (not entry/exit)
         """
-        if use_log:
-            # Sum alpha and beta in log space
-            log_gamma = alpha + beta
-            # Compute normalization term for each time step
-            log_norm = np.logaddexp.reduce(log_gamma, axis=0)
-            # Normalize (subtract in log space = divide in normal space)
-            log_gamma = log_gamma - log_norm
-            # Convert back to normal space and return only real states
-            gamma = np.exp(log_gamma[1:-1])
-        else:
-            gamma = alpha * beta
-            gamma = gamma / np.sum(gamma, axis=0)
-            gamma = gamma[1:-1]
+        # Sum alpha and beta in log space
+        log_gamma = alpha + beta
+        # Compute normalization term for each time step
+        log_norm = np.logaddexp.reduce(log_gamma, axis=0)
+        # Normalize (subtract in log space = divide in normal space)
+        log_gamma = log_gamma - log_norm
+        # Convert back to normal space and return only real states
+        gamma = np.exp(log_gamma[1:-1])
         return gamma
 
     def compute_xi(
@@ -336,7 +274,6 @@ class HMM:
         alpha: np.ndarray,
         beta: np.ndarray,
         emission_matrix: np.ndarray,
-        use_log=True,
     ) -> np.ndarray:
         """Calculate the probability of transitioning between states at each time step."""
         T = alpha.shape[1]
@@ -347,22 +284,14 @@ class HMM:
             """Calculate probability of transitioning from state i to j at time t.
             xi(t,i,j) = [alpha(t,i) * a_ij * b_j(O_t+1) * beta(t+1,j)] / P(O|lambda)
             """
-            if use_log:
-                prob = (
-                    alpha[i + 1, t]  # Being in state i
-                    + np.log(self.A[i + 1, j + 1])  # Transitioning to state j
-                    + emission_matrix[j, t + 1]  # Observing next symbol in state j
-                    + beta[j + 1, t + 1]  # Future observations from state j
-                    - np.logaddexp.reduce(alpha[:, -1])
-                )  # Normalize by total probability
-                return np.exp(prob)
-            else:
-                return (
-                    alpha[i + 1, t]
-                    * self.A[i + 1, j + 1]
-                    * emission_matrix[j, t + 1]
-                    * beta[j + 1, t + 1]
-                ) / np.sum(alpha[:, -1])
+            prob = (
+                alpha[i + 1, t]  # Being in state i
+                + np.log(self.A[i + 1, j + 1])  # Transitioning to state j
+                + emission_matrix[j, t + 1]  # Observing next symbol in state j
+                + beta[j + 1, t + 1]  # Future observations from state j
+                - np.logaddexp.reduce(alpha[:, -1])
+            )  # Normalize by total probability
+            return np.exp(prob)
 
         # Calculate probabilities for each time step
         for t in range(T - 1):
@@ -545,10 +474,10 @@ class HMM:
             for seq_idx, features in enumerate(features_list):
                 # Compute forward-backward statistics
                 log_B = self.compute_emission_matrix(features)
-                alpha = self.forward(log_B, use_log=True)
-                beta = self.backward(log_B, use_log=True)
-                gamma = self.compute_gamma(alpha, beta, use_log=True)
-                xi = self.compute_xi(alpha, beta, log_B, use_log=True)
+                alpha = self.forward(log_B)
+                beta = self.backward(log_B)
+                gamma = self.compute_gamma(alpha, beta)
+                xi = self.compute_xi(alpha, beta, log_B)
 
                 gamma_per_seq.append(gamma)
 

--- a/assignment2/hmm_fb.py
+++ b/assignment2/hmm_fb.py
@@ -1,0 +1,125 @@
+from hmmlearn import hmm
+import numpy as np
+from scipy.special import logsumexp
+from mfcc_extract import load_mfccs_by_word
+
+def calculate_emission_probs(X, means, covars):
+    """
+    Calculate log emission probabilities for a Gaussian HMM.
+    
+    Args:
+        X: Features of shape (T, n_features)
+        means: Mean vectors of shape (n_states, n_features)
+        covars: Covariance matrices of shape (n_states, n_features)
+    
+    Returns:
+        Log emission probabilities of shape (T, n_states)
+    """
+    n_samples, n_features = X.shape
+    n_states = means.shape[0]
+    
+    # Initialize output matrix
+    log_emissions = np.zeros((n_samples, n_states))
+    
+    # Constants for Gaussian probability calculation
+    const = -0.5 * (n_features * np.log(2 * np.pi))
+    
+    # Calculate for each state
+    for j in range(n_states):
+        # Get state-specific parameters
+        state_mean = means[j]
+        state_covar = covars[j]
+        
+        # Calculate log determinant term
+        log_det = -0.5 * np.sum(np.log(state_covar))
+        
+        # Calculate Mahalanobis distance
+        diff = X - state_mean
+        mahalanobis = -0.5 * np.sum((diff ** 2) / state_covar, axis=1)
+        
+        # Combine terms
+        log_emissions[:, j] = const + log_det + mahalanobis
+    
+    return log_emissions
+
+def inspect_forward_pass(word="heed"):
+    """
+    Analyze emission probabilities and forward pass calculations.
+    """
+    # Load and prepare features
+    features = load_mfccs_by_word("feature_set", word)
+    X = features[0].T  # Shape becomes (T, 13)
+    
+    print("\nData Information:")
+    print(f"Original feature shape: {features[0].shape}")
+    print(f"Transformed feature shape: {X.shape}")
+    
+    # Model parameters
+    n_states = 8
+    n_features = X.shape[1]  # Should be 13
+    
+    # Calculate global statistics
+    means = np.mean(X, axis=0)
+    covars = np.var(X, axis=0)
+    
+    # Add variance floor
+    min_covar = 1e-3
+    covars = np.maximum(covars, min_covar)
+    
+    # Replicate for each state
+    state_means = np.tile(means, (n_states, 1))
+    state_covars = np.tile(covars, (n_states, 1))
+    
+    # Calculate emission probabilities
+    log_emissions = calculate_emission_probs(X, state_means, state_covars)
+    
+    # Initialize transition matrix
+    transmat = np.zeros((n_states, n_states))
+    for i in range(n_states-1):
+        transmat[i, i] = 0.8
+        transmat[i, i+1] = 0.2
+    transmat[-1, -1] = 1.0
+    
+    # Initialize start probabilities
+    startprob = np.zeros(n_states)
+    startprob[0] = 1.0
+    
+    # Forward pass calculation
+    T = len(X)
+    log_alpha = np.full((T, n_states), -np.inf)
+    
+    # Initialize first timestep
+    log_alpha[0] = np.log(startprob) + log_emissions[0]
+    
+    # Forward recursion
+    for t in range(1, T):
+        for j in range(n_states):
+            # Previous values + transitions
+            prev_alpha = log_alpha[t-1] + np.log(transmat[:, j])
+            log_alpha[t, j] = logsumexp(prev_alpha) + log_emissions[t, j]
+    
+    print("\nEmission Probability Statistics:")
+    print(f"Min log emission: {log_emissions.min():.2f}")
+    print(f"Max log emission: {log_emissions.max():.2f}")
+    print(f"Mean log emission: {log_emissions.mean():.2f}")
+    
+    print("\nForward Variable Statistics:")
+    valid_alphas = log_alpha[log_alpha > -np.inf]
+    print(f"Min log alpha (excluding -inf): {valid_alphas.min():.2f}")
+    print(f"Max log alpha: {log_alpha.max():.2f}")
+    print(f"Mean log alpha (excluding -inf): {valid_alphas.mean():.2f}")
+    
+    print("\nDetailed Example (first 3 timesteps, first 3 states):")
+    print("\nLog Emissions:")
+    print(log_emissions[:3, :3])
+    print("\nLog Alpha:")
+    print(log_alpha[:3, :3])
+    
+    # Final log-likelihood
+    log_likelihood = logsumexp(log_alpha[-1])
+    print("\nSequence log-likelihood:", log_likelihood)
+    
+    return log_emissions, log_alpha, state_means, state_covars
+
+if __name__ == "__main__":
+    emissions, alphas, means, covars = inspect_forward_pass()

--- a/assignment2/test_custom_hmm.py
+++ b/assignment2/test_custom_hmm.py
@@ -1,0 +1,63 @@
+from hmm import HMM
+from mfcc_extract import load_mfccs_by_word
+import numpy as np
+
+def test_hmm_initialization(word="heed", n_states=8):
+    """
+    Test the initialization of HMM parameters and compare with reference values.
+    """
+    print("Testing HMM initialization parameters\n")
+    
+    # Load features for the word
+    features = load_mfccs_by_word("feature_set", word)
+    
+    # Calculate reference values directly
+    total_frames = sum(f.shape[1] for f in features)
+    avg_frames_per_state = total_frames / (len(features) * n_states)
+    ref_aii = np.exp(-1 / (avg_frames_per_state - 1))
+    ref_aij = 1 - ref_aii
+    
+    print("Reference Values:")
+    print(f"Total frames: {total_frames}")
+    print(f"Number of sequences: {len(features)}")
+    print(f"Average frames per state: {avg_frames_per_state:.2f}")
+    print(f"Calculated self-transition (aii): {ref_aii:.3f}")
+    print(f"Calculated forward transition (aij): {ref_aij:.3f}")
+    
+    # Initialize your HMM
+    print("\nYour HMM Initialization:")
+    hmm = HMM(n_states, 13, features, model_name=word)
+    
+    # Get transition probabilities from your A matrix (excluding entry/exit states)
+    your_aii = hmm.A[1, 1]  # First real state self-transition
+    your_aij = hmm.A[1, 2]  # First real state forward transition
+    
+    print(f"Your self-transition (aii): {your_aii:.3f}")
+    print(f"Your forward transition (aij): {your_aij:.3f}")
+    
+    # Compare global statistics
+    print("\nComparing means and variances:")
+    
+    # Calculate reference global statistics
+    features_concat = np.concatenate([f for f in features], axis=1)
+    ref_means = np.mean(features_concat, axis=1)
+    ref_vars = np.var(features_concat, axis=1)
+    
+    print("\nMeans comparison (first 3 dimensions):")
+    print(f"Reference: {ref_means[:3]}")
+    print(f"Your HMM:   {hmm.B['mean'][:3, 0]}")  # First state means
+    
+    print("\nVariances comparison (first 3 dimensions):")
+    print(f"Reference: {ref_vars[:3]}")
+    print(f"Your HMM:   {hmm.B['covariance'][:3, 0]}")  # First state variances
+    
+    # Calculate differences
+    mean_diff = np.abs(ref_means - hmm.B['mean'][:, 0])
+    var_diff = np.abs(ref_vars - hmm.B['covariance'][:, 0])
+    
+    print("\nDifferences:")
+    print(f"Maximum mean difference: {np.max(mean_diff):.6f}")
+    print(f"Maximum variance difference: {np.max(var_diff):.6f}")
+
+if __name__ == "__main__":
+    test_hmm_initialization()

--- a/assignment2/tests/test_emissions.py
+++ b/assignment2/tests/test_emissions.py
@@ -1,0 +1,156 @@
+import numpy as np
+from hmm import HMM
+
+def test_emission_parameter_stability():
+    """Test numerical stability of emission parameter updates during training."""
+    # Initialize with small synthetic dataset
+    num_states = 8
+    num_obs = 13
+    num_frames = 100
+    
+    # Create a simple feature set for initialization
+    np.random.seed(42)
+    init_feature = np.random.randn(num_obs, num_frames)
+    feature_set = [init_feature]
+    
+    # Initialize HMM
+    hmm = HMM(num_states, num_obs, feature_set)
+    
+    # Create training data with two distinct clusters
+    training_features = [
+        np.random.randn(num_obs, num_frames) * 2 + 5,  # Cluster 1
+        np.random.randn(num_obs, num_frames) * 2 - 5   # Cluster 2
+    ]
+    
+    # Create corresponding gamma values that encourage states to specialize
+    gamma_sequences = []
+    for seq_idx, _ in enumerate(training_features):
+        gamma = np.zeros((num_states, num_frames))
+        # Assign frames roughly equally across first half of states for first sequence
+        # and second half of states for second sequence
+        frames_per_state = num_frames // (num_states // 2)
+        start_state = seq_idx * (num_states // 2)
+        end_state = start_state + (num_states // 2)
+        
+        for s in range(start_state, end_state):
+            start_idx = (s - start_state) * frames_per_state
+            end_idx = start_idx + frames_per_state
+            if end_idx > num_frames:
+                end_idx = num_frames
+            gamma[s, start_idx:end_idx] = 1.0
+        gamma_sequences.append(gamma)
+    
+    # Test stability over multiple updates
+    num_updates = 5
+    
+    print("\nInitial statistics:")
+    print(f"Mean range: [{np.min(hmm.B['mean'])}, {np.max(hmm.B['mean'])}]")
+    print(f"Variance range: [{np.min(hmm.B['covariance'])}, {np.max(hmm.B['covariance'])}]")
+    
+    for i in range(num_updates):
+        hmm.update_B(training_features, gamma_sequences)
+        
+        # Verify basic statistical properties
+        assert np.all(np.isfinite(hmm.B['mean'])), f"Non-finite values in means at iteration {i}"
+        assert np.all(np.isfinite(hmm.B['covariance'])), f"Non-finite values in variances at iteration {i}"
+        assert np.all(hmm.B['covariance'] > 0), f"Non-positive variances at iteration {i}"
+        
+        # Check for reasonable bounds
+        assert np.all(np.abs(hmm.B['mean']) < 1000), f"Means too large at iteration {i}"
+        assert np.all(hmm.B['covariance'] < 50000), f"Variances too large at iteration {i}"
+        
+        print(f"\nUpdate {i+1} statistics:")
+        print(f"Mean range: [{np.min(hmm.B['mean'])}, {np.max(hmm.B['mean'])}]")
+        print(f"Variance range: [{np.min(hmm.B['covariance'])}, {np.max(hmm.B['covariance'])}]")
+        
+        # Verify variance floor is maintained for each state
+        for j in range(num_states):
+            var_floor = 0.01 * np.mean(hmm.B['covariance'][:, j])
+            assert np.all(hmm.B['covariance'][:, j] >= var_floor), f"Variance floor violated for state {j} at iteration {i}"
+
+def test_emission_update_correctness():
+    """Test correctness of emission parameter updates with simple cases."""
+    num_states = 2
+    num_obs = 2
+    
+    # Initialize with zero features
+    init_feature = np.zeros((num_obs, 4))
+    hmm = HMM(num_states, num_obs, [init_feature])
+    
+    # Create a simple feature set with two clear clusters
+    features = [np.array([
+        [0, 0, 10, 10],  # First dimension
+        [0, 0, 10, 10]   # Second dimension
+    ])]
+    
+    gamma = [np.array([
+        [1, 1, 0, 0],    # State 1 owns first two frames
+        [0, 0, 1, 1]     # State 2 owns last two frames
+    ])]
+    
+    print("\nTesting with simple clustered data:")
+    print("Initial parameters:")
+    print(f"Means:\n{hmm.B['mean']}")
+    print(f"Variances:\n{hmm.B['covariance']}")
+    
+    hmm.update_B(features, gamma)
+    
+    print("\nUpdated parameters:")
+    print(f"Means:\n{hmm.B['mean']}")
+    print(f"Variances:\n{hmm.B['covariance']}")
+    
+    # After update, each state should specialize to its cluster
+    expected_means = np.array([
+        [0, 10],  # First dimension: state 1 mean = 0, state 2 mean = 10
+        [0, 10]   # Second dimension: state 1 mean = 0, state 2 mean = 10
+    ])
+    
+    np.testing.assert_array_almost_equal(
+        hmm.B['mean'],
+        expected_means,
+        decimal=1,
+        err_msg=f"Incorrect means. Expected\n{expected_means}\n, got\n{hmm.B['mean']}"
+    )
+    
+    # Variances should be very small since points in each state are identical
+    # We'll just check they're below a small threshold
+    assert np.all(hmm.B['covariance'] < 1), \
+        f"Variances too large. Expected small values, got\n{hmm.B['covariance']}"
+
+def test_emission_numerical_stability():
+    """Test numerical stability with extreme values."""
+    num_states = 8
+    num_obs = 13
+    num_frames = 50
+    
+    # Initialize with reasonable values
+    init_feature = np.random.randn(num_obs, num_frames)
+    hmm = HMM(num_states, num_obs, [init_feature])
+    
+    # Test Case 1: Very small values
+    small_features = [np.random.randn(num_obs, num_frames) * 0.001]
+    small_gamma = [np.ones((num_states, num_frames)) * 1e-10]
+    
+    print("\nTesting with very small values:")
+    print(f"Feature range: [{np.min(small_features[0])}, {np.max(small_features[0])}]")
+    print(f"Gamma range: [{np.min(small_gamma[0])}, {np.max(small_gamma[0])}]")
+    
+    hmm.update_B(small_features, small_gamma)
+    
+    assert np.all(np.isfinite(hmm.B['mean'])), "Means became non-finite with small values"
+    assert np.all(np.isfinite(hmm.B['covariance'])), "Variances became non-finite with small values"
+    assert np.all(hmm.B['covariance'] > 0), "Non-positive variances with small values"
+    
+    # Test Case 2: Very large values
+    large_features = [np.random.randn(num_obs, num_frames) * 1e3]
+    large_gamma = [np.random.dirichlet([1] * num_states, num_frames).T]
+    
+    print("\nTesting with very large values:")
+    print(f"Feature range: [{np.min(large_features[0])}, {np.max(large_features[0])}]")
+    print(f"Gamma range: [{np.min(large_gamma[0])}, {np.max(large_gamma[0])}]")
+    
+    hmm.update_B(large_features, large_gamma)
+    
+    assert np.all(np.isfinite(hmm.B['mean'])), "Means became non-finite with large values"
+    assert np.all(np.isfinite(hmm.B['covariance'])), "Variances became non-finite with large values"
+    assert np.all(hmm.B['covariance'] > 0), "Non-positive variances with large values"

--- a/assignment2/tests/test_initialization.py
+++ b/assignment2/tests/test_initialization.py
@@ -12,24 +12,52 @@ def hmm_model(feature_set):
    return HMM(8, 13, feature_set)
 
 def test_hmm_initialization(hmm_model, feature_set):
-   # Test dimensions
-   assert hmm_model.B["mean"].shape == (13, 8), "Mean matrix should be (num_obs, num_states)"
-   assert hmm_model.B["covariance"].shape == (13, 8), "Covariance matrix should be (num_obs, num_states)"
-   
-   # Test variance floor was applied
-   var_floor = 0.01 * np.mean(hmm_model.variance)
-   assert np.all(hmm_model.B["covariance"] >= var_floor), "All variances should be >= variance floor"
-   
-   # Test that means and covariances are properly tiled
-   # Since we initialize with global stats, all columns should be identical
-   for i in range(1, 8):
-       np.testing.assert_array_almost_equal(
-           hmm_model.B["mean"][:, 0], 
-           hmm_model.B["mean"][:, i],
-           err_msg="All state means should be identical at initialization"
-       )
-       np.testing.assert_array_almost_equal(
-           hmm_model.B["covariance"][:, 0],
-           hmm_model.B["covariance"][:, i],
-           err_msg="All state covariances should be identical at initialization"
-       )
+    """
+    Test the initialization of HMM emission parameters.
+    
+    This test verifies that:
+    1. The parameter matrices have correct dimensions
+    2. The variance floor is properly applied for each state
+    3. Initial parameters are properly replicated across states
+    4. The parameters are finite and make statistical sense
+    """
+    # Test 1: Check dimensions of emission parameter matrices
+    assert hmm_model.B["mean"].shape == (13, 8), \
+        f"Mean matrix should be (num_obs, num_states), got shape {hmm_model.B['mean'].shape}"
+    assert hmm_model.B["covariance"].shape == (13, 8), \
+        f"Covariance matrix should be (num_obs, num_states), got shape {hmm_model.B['covariance'].shape}"
+    
+    # Test 2: Check variance floor application
+    # We compute floor based on mean of variances across all states
+    mean_variance = np.mean(hmm_model.B["covariance"])
+    var_floor = 0.01 * mean_variance
+    assert np.all(hmm_model.B["covariance"] >= var_floor), \
+        f"All variances should be >= variance floor ({var_floor}). Min variance: {np.min(hmm_model.B['covariance'])}"
+    
+    # Test 3: Verify parameter tiling
+    # At initialization, all states should have identical parameters
+    for i in range(1, 8):
+        np.testing.assert_array_almost_equal(
+            hmm_model.B["mean"][:, 0], 
+            hmm_model.B["mean"][:, i],
+            err_msg=f"State {i} means differ from state 0: \nState 0: {hmm_model.B['mean'][:, 0]}\nState {i}: {hmm_model.B['mean'][:, i]}"
+        )
+        np.testing.assert_array_almost_equal(
+            hmm_model.B["covariance"][:, 0],
+            hmm_model.B["covariance"][:, i],
+            err_msg=f"State {i} covariances differ from state 0: \nState 0: {hmm_model.B['covariance'][:, 0]}\nState {i}: {hmm_model.B['covariance'][:, i]}"
+        )
+    
+    # Test 4: Check statistical validity
+    assert np.all(np.isfinite(hmm_model.B["mean"])), \
+        "Mean matrix contains non-finite values"
+    assert np.all(np.isfinite(hmm_model.B["covariance"])), \
+        "Covariance matrix contains non-finite values"
+    assert np.all(hmm_model.B["covariance"] > 0), \
+        "Covariance matrix contains non-positive values"
+    
+    # Print initialization statistics for debugging
+    print("\nHMM Initialization Statistics:")
+    print(f"Mean range: [{np.min(hmm_model.B['mean']):.3f}, {np.max(hmm_model.B['mean']):.3f}]")
+    print(f"Variance range: [{np.min(hmm_model.B['covariance']):.3f}, {np.max(hmm_model.B['covariance']):.3f}]")
+    print(f"Variance floor: {var_floor:.3f}")

--- a/assignment2/tests/test_initialization.py
+++ b/assignment2/tests/test_initialization.py
@@ -3,18 +3,21 @@ import numpy as np
 from hmm import HMM
 from mfcc_extract import load_mfccs
 
+
 @pytest.fixture
 def feature_set():
-   return load_mfccs("feature_set")
+    return load_mfccs("feature_set")
 
-@pytest.fixture 
+
+@pytest.fixture
 def hmm_model(feature_set):
-   return HMM(8, 13, feature_set)
+    return HMM(8, 13, feature_set)
+
 
 def test_hmm_initialization(hmm_model, feature_set):
     """
     Test the initialization of HMM emission parameters.
-    
+
     This test verifies that:
     1. The parameter matrices have correct dimensions
     2. The variance floor is properly applied for each state
@@ -22,42 +25,54 @@ def test_hmm_initialization(hmm_model, feature_set):
     4. The parameters are finite and make statistical sense
     """
     # Test 1: Check dimensions of emission parameter matrices
-    assert hmm_model.B["mean"].shape == (13, 8), \
-        f"Mean matrix should be (num_obs, num_states), got shape {hmm_model.B['mean'].shape}"
-    assert hmm_model.B["covariance"].shape == (13, 8), \
-        f"Covariance matrix should be (num_obs, num_states), got shape {hmm_model.B['covariance'].shape}"
-    
+    assert hmm_model.B["mean"].shape == (
+        13,
+        8,
+    ), f"Mean matrix should be (num_obs, num_states), got shape {hmm_model.B['mean'].shape}"
+    assert hmm_model.B["covariance"].shape == (
+        13,
+        8,
+    ), f"Covariance matrix should be (num_obs, num_states), got shape {hmm_model.B['covariance'].shape}"
+
     # Test 2: Check variance floor application
     # We compute floor based on mean of variances across all states
     mean_variance = np.mean(hmm_model.B["covariance"])
     var_floor = 0.01 * mean_variance
-    assert np.all(hmm_model.B["covariance"] >= var_floor), \
-        f"All variances should be >= variance floor ({var_floor}). Min variance: {np.min(hmm_model.B['covariance'])}"
-    
+    assert np.all(
+        hmm_model.B["covariance"] >= var_floor
+    ), f"All variances should be >= variance floor ({var_floor}). Min variance: {np.min(hmm_model.B['covariance'])}"
+
     # Test 3: Verify parameter tiling
     # At initialization, all states should have identical parameters
     for i in range(1, 8):
         np.testing.assert_array_almost_equal(
-            hmm_model.B["mean"][:, 0], 
+            hmm_model.B["mean"][:, 0],
             hmm_model.B["mean"][:, i],
-            err_msg=f"State {i} means differ from state 0: \nState 0: {hmm_model.B['mean'][:, 0]}\nState {i}: {hmm_model.B['mean'][:, i]}"
+            err_msg=f"State {i} means differ from state 0: \nState 0: {hmm_model.B['mean'][:, 0]}\nState {i}: {hmm_model.B['mean'][:, i]}",
         )
         np.testing.assert_array_almost_equal(
             hmm_model.B["covariance"][:, 0],
             hmm_model.B["covariance"][:, i],
-            err_msg=f"State {i} covariances differ from state 0: \nState 0: {hmm_model.B['covariance'][:, 0]}\nState {i}: {hmm_model.B['covariance'][:, i]}"
+            err_msg=f"State {i} covariances differ from state 0: \nState 0: {hmm_model.B['covariance'][:, 0]}\nState {i}: {hmm_model.B['covariance'][:, i]}",
         )
-    
+
     # Test 4: Check statistical validity
-    assert np.all(np.isfinite(hmm_model.B["mean"])), \
-        "Mean matrix contains non-finite values"
-    assert np.all(np.isfinite(hmm_model.B["covariance"])), \
-        "Covariance matrix contains non-finite values"
-    assert np.all(hmm_model.B["covariance"] > 0), \
-        "Covariance matrix contains non-positive values"
-    
+    assert np.all(
+        np.isfinite(hmm_model.B["mean"])
+    ), "Mean matrix contains non-finite values"
+    assert np.all(
+        np.isfinite(hmm_model.B["covariance"])
+    ), "Covariance matrix contains non-finite values"
+    assert np.all(
+        hmm_model.B["covariance"] > 0
+    ), "Covariance matrix contains non-positive values"
+
     # Print initialization statistics for debugging
     print("\nHMM Initialization Statistics:")
-    print(f"Mean range: [{np.min(hmm_model.B['mean']):.3f}, {np.max(hmm_model.B['mean']):.3f}]")
-    print(f"Variance range: [{np.min(hmm_model.B['covariance']):.3f}, {np.max(hmm_model.B['covariance']):.3f}]")
+    print(
+        f"Mean range: [{np.min(hmm_model.B['mean']):.3f}, {np.max(hmm_model.B['mean']):.3f}]"
+    )
+    print(
+        f"Variance range: [{np.min(hmm_model.B['covariance']):.3f}, {np.max(hmm_model.B['covariance']):.3f}]"
+    )
     print(f"Variance floor: {var_floor:.3f}")

--- a/assignment2/tests/test_training.py
+++ b/assignment2/tests/test_training.py
@@ -44,8 +44,8 @@ def test_emission_matrix(hmm_model, feature_set):
 
 def test_fb_probabilities(hmm_model, feature_set):
     emission_matrix = hmm_model.compute_emission_matrix(feature_set[0])
-    alpha = hmm_model.forward(emission_matrix, use_log=True)
-    beta = hmm_model.backward(emission_matrix, use_log=True)
+    alpha = hmm_model.forward(emission_matrix)
+    beta = hmm_model.backward(emission_matrix)
     T = emission_matrix.shape[1]
     # Test 1: First observation emission * first backward probability
     test1 = emission_matrix[0, 0] + beta[0, 0]
@@ -66,8 +66,8 @@ def test_fb_probabilities(hmm_model, feature_set):
 
 def test_gamma_xi_probabilities(hmm_model, feature_set):
     emission_matrix = hmm_model.compute_emission_matrix(feature_set[0])
-    alpha = hmm_model.forward(emission_matrix, use_log=True)
-    beta = hmm_model.backward(emission_matrix, use_log=True)
+    alpha = hmm_model.forward(emission_matrix)
+    beta = hmm_model.backward(emission_matrix)
     gamma = hmm_model.compute_gamma(alpha, beta)
     xi = hmm_model.compute_xi(alpha, beta, emission_matrix)
     assert xi.shape == (
@@ -100,12 +100,12 @@ def test_update_transitions(hmm_model, heed_features):
     for seq_idx, heed_feature in enumerate(heed_features):
         # Compute forward-backward statistics for this sequence
         emission_matrix = hmm_model.compute_emission_matrix(heed_feature)
-        alpha = hmm_model.forward(emission_matrix, use_log=True)
-        beta = hmm_model.backward(emission_matrix, use_log=True)
+        alpha = hmm_model.forward(emission_matrix)
+        beta = hmm_model.backward(emission_matrix)
 
         # Compute gamma and xi for this sequence
-        gamma = hmm_model.compute_gamma(alpha, beta, use_log=True)
-        xi = hmm_model.compute_xi(alpha, beta, emission_matrix, use_log=True)
+        gamma = hmm_model.compute_gamma(alpha, beta)
+        xi = hmm_model.compute_xi(alpha, beta, emission_matrix)
 
         # Accumulate statistics
         aggregated_gamma += np.sum(gamma, axis=1, keepdims=True)
@@ -205,9 +205,9 @@ def test_update_emissions(hmm_model, heed_features):
     # Compute gamma for each sequence
     for features in heed_features:
         emission_matrix = hmm_model.compute_emission_matrix(features)
-        alpha = hmm_model.forward(emission_matrix, use_log=True)
-        beta = hmm_model.backward(emission_matrix, use_log=True)
-        gamma = hmm_model.compute_gamma(alpha, beta, use_log=True)
+        alpha = hmm_model.forward(emission_matrix)
+        beta = hmm_model.backward(emission_matrix)
+        gamma = hmm_model.compute_gamma(alpha, beta)
         gamma_per_seq.append(gamma)
 
         # Print basic sequence info for debugging

--- a/assignment2/tests/test_training.py
+++ b/assignment2/tests/test_training.py
@@ -248,4 +248,4 @@ def test_baum_welch(hmm_model, heed_features):
     Test the full Baum-Welch algorithm using the 'heed' sequences.
     Verifies that the model parameters converge to a stable state.
     """
-    hmm_model.baum_welch(heed_features, 15)
+    hmm_model.baum_welch(heed_features, 5)

--- a/assignment2/tests/test_training.py
+++ b/assignment2/tests/test_training.py
@@ -211,8 +211,8 @@ def test_update_emissions(hmm_model, heed_features):
         gamma_per_seq.append(gamma)
         
         # Print basic sequence info for debugging
-        print(f"\nSequence length: {features.shape[1]} frames")
-        print(f"Gamma sum: {np.sum(gamma):.3f}")
+        # print(f"\nSequence length: {features.shape[1]} frames")
+        # print(f"Gamma sum: {np.sum(gamma):.3f}")
     
     # Update emission parameters
     hmm_model.update_B(heed_features, gamma_per_seq)
@@ -248,4 +248,4 @@ def test_baum_welch(hmm_model, heed_features):
     Test the full Baum-Welch algorithm using the 'heed' sequences.
     Verifies that the model parameters converge to a stable state.
     """
-    hmm_model.baum_welch(heed_features)
+    hmm_model.baum_welch(heed_features, 1)

--- a/assignment2/tests/test_training.py
+++ b/assignment2/tests/test_training.py
@@ -3,6 +3,7 @@ import numpy as np
 from hmm import HMM
 from mfcc_extract import load_mfccs, load_mfccs_by_word
 
+
 @pytest.fixture
 def feature_set():
     return load_mfccs("feature_set")
@@ -197,10 +198,10 @@ def test_update_emissions(hmm_model, heed_features):
     # Store initial parameters to check if they change
     initial_means = hmm_model.B["mean"].copy()
     initial_variances = hmm_model.B["covariance"].copy()
-    
+
     # Use first three sequences for a simple test
     gamma_per_seq = []
-    
+
     # Compute gamma for each sequence
     for features in heed_features:
         emission_matrix = hmm_model.compute_log_emission_matrix(features)
@@ -208,38 +209,43 @@ def test_update_emissions(hmm_model, heed_features):
         beta = hmm_model.backward(emission_matrix, use_log=True)
         gamma = hmm_model.compute_gamma(alpha, beta, use_log=True)
         gamma_per_seq.append(gamma)
-        
+
         # Print basic sequence info for debugging
         # print(f"\nSequence length: {features.shape[1]} frames")
         # print(f"Gamma sum: {np.sum(gamma):.3f}")
-    
+
     # Update emission parameters
     hmm_model.update_B(heed_features, gamma_per_seq)
-    
+
     # === Basic Verification Checks ===
-    
+
     # 1. Check that parameters actually changed
-    assert not np.array_equal(initial_means, hmm_model.B["mean"]), \
-        "Means should be updated"
-    assert not np.array_equal(initial_variances, hmm_model.B["covariance"]), \
-        "Variances should be updated"
-    
+    assert not np.array_equal(
+        initial_means, hmm_model.B["mean"]
+    ), "Means should be updated"
+    assert not np.array_equal(
+        initial_variances, hmm_model.B["covariance"]
+    ), "Variances should be updated"
+
     # 2. Check mathematical validity
-    assert np.all(np.isfinite(hmm_model.B["mean"])), \
-        "All means should be finite"
-    assert np.all(np.isfinite(hmm_model.B["covariance"])), \
-        "All variances should be finite"
-    assert np.all(hmm_model.B["covariance"] > 0), \
-        "All variances should be positive"
-    
+    assert np.all(np.isfinite(hmm_model.B["mean"])), "All means should be finite"
+    assert np.all(
+        np.isfinite(hmm_model.B["covariance"])
+    ), "All variances should be finite"
+    assert np.all(hmm_model.B["covariance"] > 0), "All variances should be positive"
+
     # Print before/after statistics for inspection
     print("\nMean value ranges:")
     print(f"Before: [{np.min(initial_means):.3f}, {np.max(initial_means):.3f}]")
-    print(f"After:  [{np.min(hmm_model.B['mean']):.3f}, {np.max(hmm_model.B['mean']):.3f}]")
-    
+    print(
+        f"After:  [{np.min(hmm_model.B['mean']):.3f}, {np.max(hmm_model.B['mean']):.3f}]"
+    )
+
     print("\nVariance ranges:")
     print(f"Before: [{np.min(initial_variances):.3f}, {np.max(initial_variances):.3f}]")
-    print(f"After:  [{np.min(hmm_model.B['covariance']):.3f}, {np.max(hmm_model.B['covariance']):.3f}]")
+    print(
+        f"After:  [{np.min(hmm_model.B['covariance']):.3f}, {np.max(hmm_model.B['covariance']):.3f}]"
+    )
 
 
 def test_baum_welch(hmm_model, heed_features):

--- a/assignment2/tests/test_training.py
+++ b/assignment2/tests/test_training.py
@@ -248,4 +248,4 @@ def test_baum_welch(hmm_model, heed_features):
     Test the full Baum-Welch algorithm using the 'heed' sequences.
     Verifies that the model parameters converge to a stable state.
     """
-    hmm_model.baum_welch(heed_features, 1)
+    hmm_model.baum_welch(heed_features, 15)

--- a/assignment2/tests/test_training.py
+++ b/assignment2/tests/test_training.py
@@ -119,12 +119,11 @@ def test_update_transitions(hmm_model, heed_features):
         ), "Xi sum should equal T-1"
 
     print("\nInitial A matrix:")
-    hmm_model.print_transition_matrix()
-
+    hmm_model.print_matrix(hmm_model.A, "Transition Matrix", col="State", idx="State")
     hmm_model.update_A(aggregated_xi, aggregated_gamma)
 
     print("\nUpdated A matrix:")
-    hmm_model.print_transition_matrix()
+    hmm_model.print_matrix(hmm_model.A, "Transition Matrix", col="State", idx="State")
 
     assert (
         hmm_model.A[0, 1] == 1.0

--- a/assignment2/tests/test_training.py
+++ b/assignment2/tests/test_training.py
@@ -21,7 +21,7 @@ def heed_features():
 
 def test_emission_matrix(hmm_model, feature_set):
     test_features = feature_set[0]
-    B_probs = hmm_model.compute_log_emission_matrix(test_features)
+    B_probs = hmm_model.compute_emission_matrix(test_features)
 
     # Test shape
     assert B_probs.shape == (8, test_features.shape[1])
@@ -43,7 +43,7 @@ def test_emission_matrix(hmm_model, feature_set):
 
 
 def test_fb_probabilities(hmm_model, feature_set):
-    emission_matrix = hmm_model.compute_log_emission_matrix(feature_set[0])
+    emission_matrix = hmm_model.compute_emission_matrix(feature_set[0])
     alpha = hmm_model.forward(emission_matrix, use_log=True)
     beta = hmm_model.backward(emission_matrix, use_log=True)
     T = emission_matrix.shape[1]
@@ -65,7 +65,7 @@ def test_fb_probabilities(hmm_model, feature_set):
 
 
 def test_gamma_xi_probabilities(hmm_model, feature_set):
-    emission_matrix = hmm_model.compute_log_emission_matrix(feature_set[0])
+    emission_matrix = hmm_model.compute_emission_matrix(feature_set[0])
     alpha = hmm_model.forward(emission_matrix, use_log=True)
     beta = hmm_model.backward(emission_matrix, use_log=True)
     gamma = hmm_model.compute_gamma(alpha, beta)
@@ -99,7 +99,7 @@ def test_update_transitions(hmm_model, heed_features):
     aggregated_xi = np.zeros((hmm_model.num_states, hmm_model.num_states))
     for seq_idx, heed_feature in enumerate(heed_features):
         # Compute forward-backward statistics for this sequence
-        emission_matrix = hmm_model.compute_log_emission_matrix(heed_feature)
+        emission_matrix = hmm_model.compute_emission_matrix(heed_feature)
         alpha = hmm_model.forward(emission_matrix, use_log=True)
         beta = hmm_model.backward(emission_matrix, use_log=True)
 
@@ -204,7 +204,7 @@ def test_update_emissions(hmm_model, heed_features):
 
     # Compute gamma for each sequence
     for features in heed_features:
-        emission_matrix = hmm_model.compute_log_emission_matrix(features)
+        emission_matrix = hmm_model.compute_emission_matrix(features)
         alpha = hmm_model.forward(emission_matrix, use_log=True)
         beta = hmm_model.backward(emission_matrix, use_log=True)
         gamma = hmm_model.compute_gamma(alpha, beta, use_log=True)

--- a/assignment2/tests/test_training.py
+++ b/assignment2/tests/test_training.py
@@ -3,7 +3,6 @@ import numpy as np
 from hmm import HMM
 from mfcc_extract import load_mfccs, load_mfccs_by_word
 
-
 @pytest.fixture
 def feature_set():
     return load_mfccs("feature_set")

--- a/assignment2/tests/test_training.py
+++ b/assignment2/tests/test_training.py
@@ -248,9 +248,9 @@ def test_update_emissions(hmm_model, heed_features):
     )
 
 
-def test_baum_welch(hmm_model, heed_features):
-    """
-    Test the full Baum-Welch algorithm using the 'heed' sequences.
-    Verifies that the model parameters converge to a stable state.
-    """
-    hmm_model.baum_welch(heed_features, 5)
+# def test_baum_welch(hmm_model, heed_features):
+#     """
+#     Test the full Baum-Welch algorithm using the 'heed' sequences.
+#     Verifies that the model parameters converge to a stable state.
+#     """
+#     hmm_model.baum_welch(heed_features, 6)

--- a/assignment2/train_hmm.py
+++ b/assignment2/train_hmm.py
@@ -53,7 +53,7 @@ def train_hmm():
     hmms = {word: HMM(8, 13, feature_set, model_name=word) for word in vocabs}
 
     for word, hmm in hmms.items():
-        log_likelihoods = hmm.baum_welch(features[word], 5)
+        log_likelihoods = hmm.baum_welch(features[word], 10)
         plot_log_likelihood(log_likelihoods, word)
         break
 

--- a/assignment2/train_hmm.py
+++ b/assignment2/train_hmm.py
@@ -53,7 +53,7 @@ def train_hmm():
     hmms = {word: HMM(8, 13, feature_set, model_name=word) for word in vocabs}
 
     for word, hmm in hmms.items():
-        log_likelihoods = hmm.baum_welch(features[word], 100)
+        log_likelihoods = hmm.baum_welch(features[word], 5)
         plot_log_likelihood(log_likelihoods, word)
         break
 

--- a/assignment2/train_hmm.py
+++ b/assignment2/train_hmm.py
@@ -53,8 +53,9 @@ def train_hmm():
     hmms = {word: HMM(8, 13, feature_set, model_name=word) for word in vocabs}
 
     for word, hmm in hmms.items():
-        log_likelihoods = hmm.baum_welch(features[word], 15)
+        log_likelihoods = hmm.baum_welch(features[word], 100)
         plot_log_likelihood(log_likelihoods, word)
+        break
 
 
 if __name__ == "__main__":

--- a/assignment2/train_hmm.py
+++ b/assignment2/train_hmm.py
@@ -33,22 +33,22 @@ def plot_log_likelihood(log_likelihoods, title=None, save_path=None):
 def train_hmm():
     vocabs = [
         "heed",
-        "hid",
-        "head",
-        "had",
-        "hard",
-        "hud",
-        "hod",
-        "hoard",
-        "hood",
-        "whod",
-        "heard",
+        # "hid",
+        # "head",
+        # "had",
+        # "hard",
+        # "hud",
+        # "hod",
+        # "hoard",
+        # "hood",
+        # "whod",
+        # "heard",
     ]
 
     feature_set = load_mfccs("feature_set")
     features = {word: load_mfccs_by_word("feature_set", word) for word in vocabs}
-    total_features_length = sum(len(features[word]) for word in vocabs)
-    assert total_features_length == len(feature_set)
+    # total_features_length = sum(len(features[word]) for word in vocabs)
+    # assert total_features_length == len(feature_set)
 
     hmms = {word: HMM(8, 13, feature_set, model_name=word) for word in vocabs}
 


### PR DESCRIPTION
This pull request includes significant updates to the `assignment2` project, focusing on adding new functionalities and improving existing ones. The most important changes include adding new makefile targets, implementing functions for debugging and comparing HMM training, and refactoring the HMM class to simplify the code and remove unnecessary log-space computations.

### Makefile Enhancements:
* [`assignment2/Makefile`](diffhunk://#diff-1b4004dace71c8c9a8955c4c0cc9d07e85c3c3925215a80eb58961c5cf66e724R18-R30): Added new targets for testing emissions, debugging, and comparing training results.

### New Functionalities:
* [`assignment2/compare_training.py`](diffhunk://#diff-7e3bdb76a0f58b8896fda051413c4f1d3d34cdd83753b2796c70f4110f4bd651R1-R103): Implemented functions to debug and compare HMM training iterations, including detailed logging of intermediate values and training progress.
* [`assignment2/debugging.py`](diffhunk://#diff-1746feef2f8a51ce3cf8d97c61c29d814e0b69bf4311dd06397baaebfc7590cdR1-R87): Added functions to initialize and train HMM parameters using global statistics and proper transition probabilities.

### Refactoring and Simplification:
* [`assignment2/hmm.py`](diffhunk://#diff-00cd06d5c544cc94729b8556ceb4a976fcb02bf6079bdead38e78f4a6de48bd8L3-L5): Refactored the HMM class to simplify the computation of emission matrices and removed unnecessary log-space computations in forward and backward methods. [[1]](diffhunk://#diff-00cd06d5c544cc94729b8556ceb4a976fcb02bf6079bdead38e78f4a6de48bd8L3-L5) [[2]](diffhunk://#diff-00cd06d5c544cc94729b8556ceb4a976fcb02bf6079bdead38e78f4a6de48bd8L34-R42) [[3]](diffhunk://#diff-00cd06d5c544cc94729b8556ceb4a976fcb02bf6079bdead38e78f4a6de48bd8L102-R104) [[4]](diffhunk://#diff-00cd06d5c544cc94729b8556ceb4a976fcb02bf6079bdead38e78f4a6de48bd8L157-L175) [[5]](diffhunk://#diff-00cd06d5c544cc94729b8556ceb4a976fcb02bf6079bdead38e78f4a6de48bd8L196-L230) [[6]](diffhunk://#diff-00cd06d5c544cc94729b8556ceb4a976fcb02bf6079bdead38e78f4a6de48bd8L273-L319) [[7]](diffhunk://#diff-00cd06d5c544cc94729b8556ceb4a976fcb02bf6079bdead38e78f4a6de48bd8L328-L339) [[8]](diffhunk://#diff-00cd06d5c544cc94729b8556ceb4a976fcb02bf6079bdead38e78f4a6de48bd8L350) [[9]](diffhunk://#diff-00cd06d5c544cc94729b8556ceb4a976fcb02bf6079bdead38e78f4a6de48bd8L359-L365)